### PR TITLE
Refactor master_worker and mqueue worker

### DIFF
--- a/conc/master_worker.go
+++ b/conc/master_worker.go
@@ -138,12 +138,6 @@ type MasterHandler interface {
 	Handle(ctx context.Context, ev MasterEvent) error
 }
 
-// WorkerHandler is the user defined handler to handle events
-// targeting a worker
-type WorkerHandler interface {
-	Handle(ctx context.Context, req WorkerEvent) (interface{}, error)
-}
-
 // MasterHandlerFunc is the implementation of MasterHandler for functions
 type MasterHandlerFunc func(ctx context.Context, ev MasterEvent) error
 

--- a/conc/worker.go
+++ b/conc/worker.go
@@ -74,6 +74,12 @@ func (e RequestWorkerEvent) GetWorker() *Worker {
 	return e.Worker
 }
 
+// WorkerHandler is the user defined handler to handle events
+// targeting a worker
+type WorkerHandler interface {
+	Handle(ctx context.Context, req WorkerEvent) (interface{}, error)
+}
+
 // WorkerHandlerFunc is the implementation of MasterHandler for functions
 type WorkerHandlerFunc func(ctx context.Context, ev WorkerEvent) (interface{}, error)
 

--- a/mqueue/mem/server.go
+++ b/mqueue/mem/server.go
@@ -46,7 +46,7 @@ func (m *Server) handle(ctx context.Context, ev conc.MasterEvent) error {
 }
 
 func (s *Server) create(ctx context.Context, ev conc.CreateWorkerEvent) error {
-	worker := NewRequestHandler(ev.Key)
+	worker := NewMessageHandler(ev.Key)
 
 	ev.Props.ErrC = nil
 	ev.Props.WorkerHandler = conc.WorkerHandlerFunc(worker.handle)


### PR DESCRIPTION
- Refactors `Worker` in `master_worker.go` into separate file, `worker.go`
- Renames `Worker` struct in `mqueue` to `MessengeHandler` to not be confused with `Worker` in `conc`