### PR TITLE
add health endpoint

### DIFF
--- a/api/v0/health/entity.go
+++ b/api/v0/health/entity.go
@@ -1,0 +1,12 @@
+package health
+
+import "github.com/oasislabs/developer-gateway/stats"
+
+// GetHealthRequest is a request to retrieve the health
+// status of the component.
+type GetHealthRequest struct{}
+
+// GetHealthResponse is the response to the health request
+type GetHealthResponse struct {
+	Health stats.HealthStatus
+}

--- a/api/v0/health/handler.go
+++ b/api/v0/health/handler.go
@@ -1,0 +1,28 @@
+package health
+
+import (
+	"context"
+
+	"github.com/oasislabs/developer-gateway/rpc"
+	"github.com/oasislabs/developer-gateway/stats"
+)
+
+type Services struct{}
+
+type HealthHandler struct{}
+
+func NewHealthHandler(services Services) HealthHandler {
+	return HealthHandler{}
+}
+
+func (h HealthHandler) GetHealth(ctx context.Context, v interface{}) (interface{}, error) {
+	_ = v.(*GetHealthRequest)
+	return &GetHealthResponse{Health: stats.Healthy}, nil
+}
+
+func BindHandler(services Services, binder rpc.HandlerBinder) {
+	handler := NewHealthHandler(services)
+
+	binder.Bind("GET", "/v0/api/health", rpc.HandlerFunc(handler.GetHealth),
+		rpc.EntityFactoryFunc(func() interface{} { return &GetHealthRequest{} }))
+}

--- a/gateway/config/config.go
+++ b/gateway/config/config.go
@@ -17,8 +17,8 @@ func (c SimpleConfigProvider) Get() Config {
 	return c.config
 }
 
-// ConfigProvider returns an instance of the configuration
-type ConfigProvider interface {
+// Provider returns an instance of the configuration
+type Provider interface {
 	// Get an instance of the configuration
 	Get() Config
 }
@@ -80,7 +80,8 @@ type AuthConfig struct {
 
 // Config is the general application's configuration
 type Config struct {
-	Bind BindConfig `mapstructure:"bind"`
+	BindPublic  BindConfig `mapstructure:"bind_public"`
+	BindPrivate BindConfig `mapstructure:"bind_private"`
 	// Wallet is the configured wallet for the application
 	Wallet       WalletConfig `mapstructure:"wallet"`
 	EthConfig    EthConfig    `mapstructure:"eth"`

--- a/rpc/health.go
+++ b/rpc/health.go
@@ -1,0 +1,1 @@
+package rpc

--- a/rpc/http_test.go
+++ b/rpc/http_test.go
@@ -272,6 +272,7 @@ func TestHttpJsonHandlerContentLengthMissingWithBody(t *testing.T) {
 	})
 
 	req, _ := http.NewRequest("GET", "/path", bytes.NewBufferString(""))
+	req.ContentLength = -1
 
 	v, err := handler.ServeHTTP(req)
 

--- a/stats/health.go
+++ b/stats/health.go
@@ -1,0 +1,19 @@
+package stats
+
+// HealthStatus of a service. This status should be advertised by
+// a service so that a health checker can know what action
+// if any is required to keep the status on a Healthy state
+type HealthStatus uint
+
+const (
+	// Healthy status means that the service is up and running
+	// and can take incoming requests
+	Healthy HealthStatus = 0
+
+	// Drain a service so that it processes the requests that
+	// already are inflight but does not take further requests
+	Drain HealthStatus = 1
+
+	// Unhealthy status for a service that should be restarted
+	Unhealthy HealthStatus = 2
+)

--- a/tests/api_test.go
+++ b/tests/api_test.go
@@ -84,34 +84,15 @@ func TestPathNoContentType(t *testing.T) {
 			Method: "POST",
 			Path:   "/v0/api/service/deploy",
 		},
-		Body: nil,
+		Body: []byte("{}"),
 		Headers: map[string]string{
 			insecure.HeaderKey:           "mykey",
 			auth.RequestHeaderSessionKey: "mysession",
-			"Content-length":             "0",
+			"Content-length":             "2",
 		},
 	})
 	assert.Nil(t, err)
 
 	assert.Equal(t, http.StatusBadRequest, res.Code)
 	assert.Equal(t, "{\"errorCode\":2004,\"description\":\"Content-type should be application/json.\"}\n", string(res.Body))
-}
-
-func TestPathNoContent(t *testing.T) {
-	res, err := apitest.NewClient(router).Request(apitest.Request{
-		Route: apitest.Route{
-			Method: "POST",
-			Path:   "/v0/api/service/deploy",
-		},
-		Body: nil,
-		Headers: map[string]string{
-			insecure.HeaderKey:           "mykey",
-			auth.RequestHeaderSessionKey: "mysession",
-			"Content-type":               "application/json",
-		},
-	})
-	assert.Nil(t, err)
-
-	assert.Equal(t, http.StatusBadRequest, res.Code)
-	assert.Equal(t, "{\"errorCode\":2005,\"description\":\"Failed to deserialize body as JSON.\"}\n", string(res.Body))
 }

--- a/tests/config/dev.toml
+++ b/tests/config/dev.toml
@@ -3,9 +3,16 @@ title = "Development configuration"
 [wallet]
 private_key = "37e3836a1c6d6db32d21ac7f2b570b8cce9272aee5bcc0e175ec599b5c8b7052"
 
-[bind]
+[bind_public]
 http_interface = "127.0.0.1"
 http_port = 1234
+http_read_timeout_ms = 10000
+http_write_timeout_ms = 10000
+http_max_header_bytes = 8192
+
+[bind_private]
+http_interface = "127.0.0.1"
+http_port = 1235
 http_read_timeout_ms = 10000
 http_write_timeout_ms = 10000
 http_max_header_bytes = 8192

--- a/tests/config/redis_single.toml
+++ b/tests/config/redis_single.toml
@@ -3,9 +3,16 @@ title = "Redis Single Instance configuration"
 [wallet]
 private_key = "37e3836a1c6d6db32d21ac7f2b570b8cce9272aee5bcc0e175ec599b5c8b7052"
 
-[bind]
+[bind_public]
 http_interface = "127.0.0.1"
 http_port = 1234
+http_read_timeout_ms = 10000
+http_write_timeout_ms = 10000
+http_max_header_bytes = 8192
+
+[bind_private]
+http_interface = "127.0.0.1"
+http_port = 1235
 http_read_timeout_ms = 10000
 http_write_timeout_ms = 10000
 http_max_header_bytes = 8192

--- a/tests/setup.go
+++ b/tests/setup.go
@@ -55,5 +55,5 @@ func InitializeWithConfig(configFile string) (*rpc.HttpRouter, error) {
 	}
 
 	gateway.RootLogger.SetOutput(ioutil.Discard)
-	return gateway.NewRouter(services), nil
+	return gateway.NewPublicRouter(services), nil
 }


### PR DESCRIPTION
Adding a health endpoint to a private interface that can be used by kubernetes to test readiness and liveness of the service.

This endpoint for now is just a shell, we can add different service metrics and other things before a production release. This is just to have an endpoint that we can call when we deploy the gateway in staging-beta