### PR TITLE
add wallet threshold

### DIFF
--- a/backend/eth/client_test.go
+++ b/backend/eth/client_test.go
@@ -46,6 +46,7 @@ func NewClient() (*Client, error) {
 	mockclient := &ethtest.MockClient{}
 	mockcallbacks := &callbacktest.MockClient{}
 
+	callbacktest.ImplementMock(mockcallbacks)
 	mockclient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).
 		Return(big.NewInt(1), nil)
 	mockclient.On("NonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil)

--- a/callback/callbacktest/mock_client.go
+++ b/callback/callbacktest/mock_client.go
@@ -17,3 +17,15 @@ func (c *MockClient) WalletOutOfFunds(
 ) {
 	_ = c.Called(ctx, body)
 }
+
+func (c *MockClient) WalletReachedFundsThreshold(
+	ctx context.Context,
+	body callback.WalletReachedFundsThresholdBody,
+) {
+	_ = c.Called(ctx, body)
+}
+
+func ImplementMock(client *MockClient) {
+	client.On("WalletOutOfFunds", mock.Anything, mock.Anything).Return()
+	client.On("WalletReachedFundsThreshold", mock.Anything, mock.Anything).Return()
+}

--- a/callback/client/entity.go
+++ b/callback/client/entity.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"html/template"
+	"math/big"
 	"time"
 )
 
@@ -47,8 +48,30 @@ type Callback struct {
 }
 
 // WalletOutOfFundsBody is the body sent on a WalletOutOfFunds
-// to the required endpoint.
+// to the required endpoint
 type WalletOutOfFundsBody struct {
 	// Address is the address of the wallet that is out of funds
 	Address string
+}
+
+// WalletReachedFundsThresholdBody is the body sent on a WalletReachedFundsThresholdBody
+// to the required endpoint
+type WalletReachedFundsThresholdBody struct {
+	// Address is the address of the wallet that reached the threshold
+	Address string
+
+	// Before the threshold of currency reached
+	Before *big.Int
+
+	// After the threshold of currency reached
+	After *big.Int
+}
+
+// WalletReachedFundsThresholdRequest is the request sent on
+// the callback
+type WalletReachedFundsThresholdRequest struct {
+	Address   string
+	Before    string
+	After     string
+	Threshold string
 }

--- a/callback/factory.go
+++ b/callback/factory.go
@@ -3,6 +3,7 @@ package callback
 import (
 	"context"
 	"html/template"
+	"math/big"
 	"net/http"
 	"time"
 
@@ -29,42 +30,77 @@ func (f CallbacksFactoryFunc) New(ctx context.Context, services *ClientServices,
 	return f(ctx, services, config)
 }
 
-func NewClientWithDeps(ctx context.Context, deps *client.Deps, config *Config) (*client.Client, error) {
+func parseCallback(name string, callback Callback) (client.Callback, error) {
 	var (
 		bodyFormat     *template.Template
 		queryURLFormat *template.Template
 	)
-	if len(config.WalletOutOfFunds.Body) > 0 {
-		tmpl, err := template.New("WalletOutOfFundsBody").Parse(config.WalletOutOfFunds.Body)
+	if len(callback.Body) > 0 {
+		tmpl, err := template.New(name).Parse(callback.Body)
 		if err != nil {
-			return nil, err
+			return client.Callback{}, err
 		}
 
 		bodyFormat = tmpl
 	}
 
-	if len(config.WalletOutOfFunds.QueryURL) > 0 {
-		tmpl, err := template.New("WalletOutOfFundsQueryURL").Parse(config.WalletOutOfFunds.QueryURL)
+	if len(callback.QueryURL) > 0 {
+		tmpl, err := template.New(name).Parse(callback.QueryURL)
 		if err != nil {
-			return nil, err
+			return client.Callback{}, err
 		}
 
 		queryURLFormat = tmpl
 	}
 
+	return client.Callback{
+		Enabled:        callback.Enabled,
+		Name:           name,
+		Method:         callback.Method,
+		URL:            callback.URL,
+		BodyFormat:     bodyFormat,
+		QueryURLFormat: queryURLFormat,
+		Headers:        callback.Headers,
+		Sync:           callback.Sync,
+		PeriodLimit:    1 * time.Minute,
+	}, nil
+}
+
+func parseWalletReachedFundsThresholdCallback(config WalletReachedFundsThreshold) (client.WalletReachedFundsThresholdCallback, error) {
+	callback, err := parseCallback("WalletReachedFundsThreshold", Callback{
+		Enabled:  config.Enabled,
+		Sync:     config.Sync,
+		Method:   config.Method,
+		URL:      config.URL,
+		Body:     config.Body,
+		QueryURL: config.QueryURL,
+		Headers:  config.Headers,
+	})
+	if err != nil {
+		return client.WalletReachedFundsThresholdCallback{}, err
+	}
+
+	return client.WalletReachedFundsThresholdCallback{
+		Callback:  callback,
+		Threshold: new(big.Int).SetUint64(config.Threshold),
+	}, nil
+}
+
+func NewClientWithDeps(ctx context.Context, deps *client.Deps, config *Config) (*client.Client, error) {
+	walletOutOfFunds, err := parseCallback("WalletOutOfFundsBody", config.WalletOutOfFunds.Callback)
+	if err != nil {
+		return nil, err
+	}
+
+	walletReachedFundsThreshold, err := parseWalletReachedFundsThresholdCallback(config.WalletReachedFundsThreshold)
+	if err != nil {
+		return nil, err
+	}
+
 	return client.NewClientWithDeps(deps, &client.Props{
 		Callbacks: client.Callbacks{
-			WalletOutOfFunds: client.Callback{
-				Enabled:        config.WalletOutOfFunds.Enabled,
-				Name:           "WalletOutOfFunds",
-				Method:         config.WalletOutOfFunds.Method,
-				URL:            config.WalletOutOfFunds.URL,
-				BodyFormat:     bodyFormat,
-				QueryURLFormat: queryURLFormat,
-				Headers:        config.WalletOutOfFunds.Headers,
-				Sync:           config.WalletOutOfFunds.Sync,
-				PeriodLimit:    1 * time.Minute,
-			},
+			WalletOutOfFunds:            walletOutOfFunds,
+			WalletReachedFundsThreshold: walletReachedFundsThreshold,
 		},
 	}), nil
 }

--- a/tests/gatewaytest/service.go
+++ b/tests/gatewaytest/service.go
@@ -41,6 +41,7 @@ func NewServices(ctx context.Context, config *gateway.Config) (*Provider, error)
 	callbackclient := &callbacktest.MockClient{}
 	provider.MustAdd(callbackclient)
 
+	callbacktest.ImplementMock(callbackclient)
 	ethclient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).
 		Return(big.NewInt(1), nil)
 


### PR DESCRIPTION
Allows to set callbacks based on a threshold a wallet balance can get lower than.