### PR TITLE
Make RetryConfig less optimistic

### DIFF
--- a/concurrent/conc.go
+++ b/concurrent/conc.go
@@ -41,10 +41,10 @@ func (e ErrMaxAttemptsReached) Error() string {
 
 const (
 	defaultConcurrency     uint8         = 2
-	defaultBaseTimeout     time.Duration = 10 * time.Millisecond
-	defaultBaseExp         uint8         = 4
+	defaultBaseTimeout     time.Duration = 100 * time.Millisecond
+	defaultBaseExp         uint8         = 2
 	defaultMaxRetryTimeout time.Duration = 10 * time.Second
-	defaultAttempts        uint8         = 5
+	defaultAttempts        uint8         = 10
 )
 
 var RandomConfig = RetryConfig{

--- a/tx/owner.go
+++ b/tx/owner.go
@@ -45,8 +45,8 @@ const gasPrice int64 = 1000000000
 var retryConfig = concurrent.RetryConfig{
 	Random:            false,
 	UnlimitedAttempts: false,
-	Attempts:          2,
-	BaseExp:           1,
+	Attempts:          10,
+	BaseExp:           2,
 	BaseTimeout:       time.Second,
 	MaxRetryTimeout:   5 * time.Second,
 }


### PR DESCRIPTION
This is to correct some of the timeout issues being experienced when deploying services via the oasis-gateway.