### PR TITLE
Fix RetryWithConfig behavior

### DIFF
--- a/concurrent/conc.go
+++ b/concurrent/conc.go
@@ -150,10 +150,14 @@ func RetryWithConfig(
 			return nil, ErrMaxAttemptsReached{Causes: errs}
 		}
 
-		// make sure that the timeout is set to at least 1ns
-		timeout = ((timeout * exp) % maxTimeout) + time.Millisecond.Nanoseconds()
+		timeout = (timeout * exp)
+		multiplier := rand.Float64() + 0.5
+		if timeout > maxTimeout {
+			timeout = maxTimeout
+			multiplier = rand.Float64() + 1
+		}
 		if config.Random {
-			timeout = int64(rand.Float64()*float64(timeout)) + 1
+			timeout = int64(multiplier*float64(timeout)) + 1
 		}
 		timer.Reset(time.Duration(timeout))
 	}


### PR DESCRIPTION
This solves `RetryWithConfig` issues in both the `Random: true` and `Random: false` cases.

When `Random: false`, the function sets the timeout to be the current timeout _modulo_ the max timeout rather than the minimum of the two. This causes cyclic timeout patterns such as:

1000000
3000000
7000000
9000000
1000000
3000000
7000000
9000000

The real problem arises with `Random: true`, which happens with the `PooledClient` used to communicate with the web3 gateway. Entropy is introduced by multiplying by a random value in `[0, 1)`, which disproportionately causes the timeout to never really grow and in fact shrink past it's base timeout. I changed this to select a random value from `[0.5, 1.5)` when the max timeout hasn't been hit and `[1, 2)` in the case when it has, and this gave rise to nicer (empirically observed) patterns. E.g:

1000000
2209321
6365094
14377142
16868231
11565193
13009119
18136400
13806572
14688899 

