### PR TITLE
Disable metrics

### DIFF
--- a/.buildkite/Dockerfile.ci
+++ b/.buildkite/Dockerfile.ci
@@ -8,7 +8,7 @@ ENV BUILDKITE_BRANCH ""
 # variable. By default this value is empty and not use a go proxy.
 ARG GOPROXY=
 
-RUN apt update && apt install -y git build-essential gcc binutils curl protobuf-compiler golang-goprotobuf-dev
+RUN apt update && apt install -y git build-essential gcc binutils curl protobuf-compiler golang-goprotobuf-dev make
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /tmp/bin v1.20.1
 
 # Prepare for coverage

--- a/api/v0/health/handler.go
+++ b/api/v0/health/handler.go
@@ -23,7 +23,7 @@ func (h HealthHandler) GetHealth(ctx context.Context, v interface{}) (interface{
 	_ = v.(*GetHealthRequest)
 	return &GetHealthResponse{
 		Health:  stats.Healthy,
-		Metrics: h.collector.Stats(),
+		Metrics: make(stats.Metrics), // disabled due to causing crash
 	}, nil
 }
 


### PR DESCRIPTION
This PR has been in prod for a long time now. The change was a hotfix to remediate restarts due to failed health checks resulting from metrics collector timeouts ([reference](https://oasis-labs.slack.com/archives/CLYD666RG/p1599200872141000?thread_ts=1599179928.139200&cid=CLYD666RG)).